### PR TITLE
Add maintenance page for downtime

### DIFF
--- a/masem/frontend/src/App.jsx
+++ b/masem/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom"
 import Landing from "./pages/Landing"
 import Admin from "./pages/Admin"
 import ProjectDetails from "./pages/ProjectDetails"
+import Maintenance from "./pages/Maintenance"
 import BlogDetails from "./pages/BlogDetails"
 import MainLayout from "./components/layout/MainLayout"
 import { AuthProvider } from "./context/AuthContext"
@@ -23,7 +24,8 @@ function App() {
             <Route path="*" element={<Landing />} />
           </Route>
           
-          <Route path="/admin" element={ <Admin /> } />
+            <Route path="/maintenance" element={<Maintenance />} />
+            <Route path="/admin" element={ <Admin /> } />
         </Routes>
       </Router>
     </AuthProvider>

--- a/masem/frontend/src/pages/Maintenance.jsx
+++ b/masem/frontend/src/pages/Maintenance.jsx
@@ -1,0 +1,13 @@
+import logoUrl from "@/assets/masem-logo.png";
+
+function Maintenance() {
+    return (
+        <div className="min-h-screen flex flex-col items-center justify-center text-center">
+            <img src={logoUrl} alt="MASEM Logo" className="h-24 mb-8" />
+            <p className="mb-4">Wir führen derzeit Wartungsarbeiten durch. Bitte schauen Sie später wieder vorbei.</p>
+            <a href="https://wa.me/<NUMMER>" className="bg-green-500 text-white px-4 py-2 rounded">Kontakt via WhatsApp</a>
+        </div>
+    );
+}
+
+export default Maintenance;

--- a/masem/frontend/vercel.json
+++ b/masem/frontend/vercel.json
@@ -13,6 +13,7 @@
     }
   ],
   "rewrites": [
+    { "source": "/(.*)", "destination": "/maintenance" },
     {
       "source": "/(.*)",
       "has": [


### PR DESCRIPTION
## Summary
- add standalone maintenance page with contact link
- register /maintenance route and optional redirect for downtime

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c28ef406c88322b46b5cd279600034