### PR TITLE
Use named parameter in Vercel redirect and remove maintenance rewrite

### DIFF
--- a/masem/frontend/vercel.json
+++ b/masem/frontend/vercel.json
@@ -1,19 +1,18 @@
 {
   "redirects": [
     {
-      "source": "/(.*)",
+      "source": "/:path*",
       "has": [
         {
           "type": "host",
           "value": "www.masem.at"
         }
       ],
-      "destination": "https://masem.at/:1",
+      "destination": "https://masem.at/:path*",
       "statusCode": 308
     }
   ],
   "rewrites": [
-    { "source": "/(.*)", "destination": "/maintenance" },
     {
       "source": "/(.*)",
       "has": [


### PR DESCRIPTION
## Summary
- replace regex capture in Vercel redirect with named `:path*` parameter
- remove catch-all rewrite to `/maintenance` so site content renders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx vercel deploy --prebuilt` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd16a1e48322bceb1144775f2b1f