### PR TITLE
Use named parameter in Vercel redirect and configure static build output

### DIFF
--- a/masem/frontend/vercel.json
+++ b/masem/frontend/vercel.json
@@ -1,19 +1,25 @@
 {
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ],
   "redirects": [
     {
-      "source": "/(.*)",
+      "source": "/:path*",
       "has": [
         {
           "type": "host",
           "value": "www.masem.at"
         }
       ],
-      "destination": "https://masem.at/:1",
+      "destination": "https://masem.at/:path*",
       "statusCode": 308
     }
   ],
   "rewrites": [
-    { "source": "/(.*)", "destination": "/maintenance" },
     {
       "source": "/(.*)",
       "has": [


### PR DESCRIPTION
## Summary
- replace regex capture in Vercel redirect with named `:path*` parameter
- remove catch-all rewrite to `/maintenance` so site content renders
- specify Vercel static build `dist` directory to ensure compiled assets are served

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx vercel deploy --prebuilt` *(fails: No existing credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd16a1e48322bceb1144775f2b1f